### PR TITLE
Fix brew installation

### DIFF
--- a/config/zshrc.sh
+++ b/config/zshrc.sh
@@ -59,5 +59,6 @@ if command -v ask-sh &> /dev/null; then
   export ASK_SH_OPENAI_MODEL=gpt-4o-mini
   eval "$(ask-sh --init)"
 fi
+eval "$(~/.linuxbrew/bin/brew shellenv zsh)"
 
 cat $CONFIG_DIR/start.txt

--- a/install.sh
+++ b/install.sh
@@ -57,13 +57,23 @@ if [ $machine == "Linux" ]; then
     if [ $extras == true ]; then
         sudo apt-get install -y ripgrep
 
-        yes | curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash
-        yes | brew install dust jless
+        if [ -x ~/.linuxbrew/bin/brew ]; then
+            echo "Homebrew already installed, skipping..."
+        else
+            git clone https://github.com/Homebrew/brew ~/.linuxbrew/Homebrew
+            mkdir -p ~/.linuxbrew/bin
+            ln -s ../Homebrew/bin/brew ~/.linuxbrew/bin/brew
+            ~/.linuxbrew/bin/brew update --force --quiet
+        fi
 
-        yes | curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        eval "$(~/.linuxbrew/bin/brew shellenv)"
+        
+        brew install dust jless
+
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         . "$HOME/.cargo/env" 
-        yes | cargo install code2prompt
-        yes | brew install peco
+        cargo install code2prompt
+        brew install peco
 
         sudo apt-get install -y npm
         yes | npm i -g shell-ask

--- a/install.sh
+++ b/install.sh
@@ -51,8 +51,14 @@ if [ $machine == "Linux" ]; then
     sudo apt-get update -y
     [ $zsh == true ] && sudo apt-get install -y zsh
     [ $tmux == true ] && sudo apt-get install -y tmux
-    sudo apt-get install -y less nano htop ncdu nvtop lsof rsync jq
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    sudo apt-get install -y less nano htop ncdu nvtop lsof rsync jq pkg-config
+
+
+    if ! command -v uv &> /dev/null; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    else
+        echo "uv already installed, skipping..."
+    fi
     
     if [ $extras == true ]; then
         sudo apt-get install -y ripgrep
@@ -76,9 +82,8 @@ if [ $machine == "Linux" ]; then
         brew install peco
 
         sudo apt-get install -y npm
-        yes | npm i -g shell-ask
+        sudo npm i -g shell-ask
     fi
-
 # Installing on mac with homebrew
 elif [ $machine == "Mac" ]; then
     yes | brew install coreutils ncdu htop ncdu rsync btop jq  # Mac won't have realpath before coreutils installed
@@ -138,6 +143,6 @@ fi
 if [ $extras == true ]; then
     echo " --------- INSTALLING EXTRAS ⏳ ----------- "
     if command -v cargo &> /dev/null; then
-        NO_ASK_OPENAI_API_KEY=1 bash -c "$(curl -fsSL https://raw.githubusercontent.com/hmirin/ask.sh/main/install.sh)"
+        NO_ASK_OPENAI_API_KEY=1 zsh -c "$(curl -fsSL https://raw.githubusercontent.com/hmirin/ask.sh/main/install.sh)"
     fi
 fi


### PR DESCRIPTION
The brew installation would fail on linux when running `./install.sh --extras` due to the `yes |` not returning 0 for some reason. 
Additionally, if run on the cluster where somebody ran the script before you, it would fail because of permissions as it would try to install brew in a shared directory `/home/linuxbrew/.linuxbrew`, overwriting the install belonging to another user.

Fixes : 
- I changed the script to install brew in the home directory instead, which works.
- Added a line in zshrc.sh to activate the correct brew each time.
- Add 'sudo' in front of the global shell-ask install as it would fail otherwise (at least on linux, on the cluster). An alternative would be not to make the install global, but I'm keeping the same spirit of the script.
- Changed `bash-> zsh` in the install command for ask.sh, as it would fail otherwise on linux on the cluster. Should be generally safe to do, I think.
- Added skip uv and linuxbrew install if already detected as installed
